### PR TITLE
Allow command subdirectories for organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "botframework-demo",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "A framework for quickly creating new Discord.js bots.",
 	"author": "Zackary Campbell <zajrik@gmail.com>",
 	"scripts": {

--- a/src/Globals.js
+++ b/src/Globals.js
@@ -60,3 +60,26 @@ Pad = (text, length) =>
 {
 	return text + ' '.repeat(length - text.length);
 }
+
+// Get filenames in a directory with subdirectories up to 1-deep
+// Anything deeper is unecessary anyway.
+GetFiles = (dir, list, subdir) =>
+{
+	var files = fs.readdirSync(dir);
+	var list = list || new Array();
+	var subdir = subdir || "";
+	files.forEach(function(file)
+	{
+		if (fs.statSync(dir + '/' + file).isDirectory())
+		{
+			subdir = `${file}/`;
+			list = GetFiles(dir + '/' + file, list, subdir);
+			subdir = "";
+		}
+		else
+		{
+			list.push(subdir + file);
+		}
+	});
+	return list;
+};

--- a/src/examples/command.example.js
+++ b/src/examples/command.example.js
@@ -24,7 +24,7 @@ class CommandName extends Command
 		this.permsissions = [];
 
 		// Activation command regex
-		this.command = /^reload$/;
+		this.command = /^command$/;
 
 		/**
 		 * Action to take when the command is received

--- a/src/lib/Bot.js
+++ b/src/lib/Bot.js
@@ -133,12 +133,16 @@ class Bot extends Client
 
 		try
 		{
-			files = fs.readdirSync("./src/commands");
+			files = GetFiles("./src/commands");
+
 		}
 		catch (e)
 		{
-			throw new Error("Failed to load Commands.");
+			throw new Error("Failed to load commands");
 		}
+
+		// No commands to load, break
+		if (files.length < 1) return;
 
 		// Load each command
 		files.forEach( (filename, index) =>
@@ -181,6 +185,9 @@ class Bot extends Client
 		{
 			throw new Error("Failed to load Tasks.");
 		}
+
+		// No tasks to load, break
+		if (files.length < 1) return;
 
 		// Load each task
 		files.forEach( (filename, index) =>


### PR DESCRIPTION
If it becomes a problem that it's only capable of loading files one level
deeper into the commands folder I may explore other options. I had success
with node-glob but it's asynchronous and will take some refactoring. But I
personally don't see the need for a depth greater than one subdirectory.
That should be more than enough for categorical/modular organization
