### PR TITLE
 fix(CommandDispatcher): don't send anything falsy as commandResult 

### DIFF
--- a/src/command/CommandDispatcher.ts
+++ b/src/command/CommandDispatcher.ts
@@ -127,7 +127,8 @@ export class CommandDispatcher
 		try { commandResult = await command.action(message, args); }
 		catch (err) { this._logger.error(`Dispatch:${command.name}`, err.stack); }
 
-		if (commandResult
+		if (commandResult !== null
+			&& typeof commandResult !== 'undefined'
 			&& !(commandResult instanceof Array)
 			&& !(commandResult instanceof DMessage))
 			commandResult = await message.channel.send(<string> commandResult);

--- a/src/command/CommandDispatcher.ts
+++ b/src/command/CommandDispatcher.ts
@@ -127,7 +127,7 @@ export class CommandDispatcher
 		try { commandResult = await command.action(message, args); }
 		catch (err) { this._logger.error(`Dispatch:${command.name}`, err.stack); }
 
-		if (typeof commandResult !== 'undefined'
+		if (commandResult
 			&& !(commandResult instanceof Array)
 			&& !(commandResult instanceof DMessage))
 			commandResult = await message.channel.send(<string> commandResult);


### PR DESCRIPTION
Resolving `Command#action` with `null` results in an unhandled rejection:
```js
Cannot read property 'embed' of null
```
This is because the CommandDispatcher will try to send that returned `null` as CommandResult to the channel.

As a side effect this PR removes the ability to send the plain number `0`, which is technically not a CommandResult anyway.
This could be accounted for if wanted.

On another note: 
Thet commandResult gets casted to a string, could it be that it's intend to only send strings?
A simple `typeof commandResult === 'string'` would do in that case.
