### PR TITLE
fix(CommandLoader): don't remove the file extensions of commands

### DIFF
--- a/src/command/CommandLoader.ts
+++ b/src/command/CommandLoader.ts
@@ -51,7 +51,7 @@ export class CommandLoader
 
 			if (this._client.commands.find(c => c.overloads === command.name))
 			{
-				this._logger.info(`Skipping exterally overloaded command: '${command.name}'`);
+				this._logger.info(`Skipping externally overloaded command: '${command.name}'`);
 				continue;
 			}
 

--- a/src/command/CommandLoader.ts
+++ b/src/command/CommandLoader.ts
@@ -39,7 +39,8 @@ export class CommandLoader
 		let loadedCommands: number = 0;
 		for (const fileName of commandFiles)
 		{
-			const commandLocation: string = fileName.replace('.js', '');
+			const { dir, name }: path.ParsedPath = path.parse(fileName);
+			const commandLocation: string = `${dir}/${name}`;
 			delete require.cache[require.resolve(commandLocation)];
 
 			const loadedCommandClass: typeof Command = this.getCommandClass(commandLocation);

--- a/src/command/CommandLoader.ts
+++ b/src/command/CommandLoader.ts
@@ -37,10 +37,8 @@ export class CommandLoader
 			commandFiles.push(...glob.sync(`${this._client.commandsDir}/**/*.js`));
 
 		let loadedCommands: number = 0;
-		for (const fileName of commandFiles)
+		for (const commandLocation of commandFiles)
 		{
-			const { dir, name }: path.ParsedPath = path.parse(fileName);
-			const commandLocation: string = `${dir}/${name}`;
 			delete require.cache[require.resolve(commandLocation)];
 
 			const loadedCommandClass: typeof Command = this.getCommandClass(commandLocation);


### PR DESCRIPTION
Found this while debugging my other issue with the null return value.

The CommandLoader will remove the first `.js` in the path, which will remove it from a folder if you are unlucky and have one with `.js` in the path of a command.

In my case:
`D:/dev/discord.js/yamdbf/bin/command/base/Eval.js` -> `D:/dev/discord/yamdbf/bin/command/base/Eval.js`
which throw an error when attempting to require.

~~This will correctly remove the file extension by using path's parse.
Note: I don't see any reason why removing the file extension is necessary, `require` and `require.resolve` both seem to work fine the file extension.~~

EDIT: Decided to not remove the extensions at all.


This is also very likely a fix for #16.
`C:/Programming/Github/Node/Core/node_modules/yamdbf/bin/command/base/Eval.js` <- with `.js` at the end
Was probably before removing the `.js`:
`C:/Programming/Github/Node.js/Core/node_modules/yamdbf/bin/command/base/Eval.js`

EDIT: ~~Sneaked a typo fix in here as well.~~