### PR TITLE
Remove tsconfig.json and tslint.json from npm release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,5 @@ config.json
 
 gulpfile.js
 yarn.lock
+tsconfig.json
+tslint.json


### PR DESCRIPTION
Remove Typescript assets from npm release.

Tsconfig.json should be reviewed as Typescript points out:
"[ts] No inputs were found in config file 'c:/Users/xxx/discord-bot/node_modules/@yamdbf/core/tsconfig.json'. Specified 'include' paths were '["**/*"]' and 'exclude' paths were '["node_modules","bower_components","jspm_packages","tmp","temp","bin","docs","pkg","examples"]'."